### PR TITLE
Fixed "Function declaration is not a prototype" warning

### DIFF
--- a/FLazyProxy.h
+++ b/FLazyProxy.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef id (^FLazyProxyResolver)();
+typedef id (^FLazyProxyResolver)(void);
 
 @interface FLazyProxy : NSProxy
 + (instancetype)proxyWithBlock:(FLazyProxyResolver)aResolver;


### PR DESCRIPTION
Occurs with CLANG_WARN_STRICT_PROTOTYPES